### PR TITLE
replace medien map with map according the ZB MEDs list

### DIFF
--- a/app/services/ArticleHelper.java
+++ b/app/services/ArticleHelper.java
@@ -150,11 +150,11 @@ public class ArticleHelper {
 	 */
 	public static LinkedHashMap<String, String> getMediumMap() {
 		LinkedHashMap<String, String> map = new LinkedHashMap<>();
-		map.put("http://pbcore.org/vocabularies/instantiationMediaType#text",
+		map.put("http://purl.org/lobid/lv#fulltextOnline",
 				"Volltext");
                 map.put("http://purl.org/dc/terms/LicenseDocument","Autorenvertrag");
-                map.put("http://purl.org/vocab/frbr/core#supplement","Beilage");
-		map.put("http://purl.org/lobid/lv%23Miscellaneous", "Andere");
+                map.put("http://id.loc.gov/ontologies/bibframe/supplement","Beilage");
+		map.put("http://purl.org/lobid/lv#Miscellaneous", "Andere");
 		return map;
 	}
 

--- a/app/services/ArticleHelper.java
+++ b/app/services/ArticleHelper.java
@@ -150,14 +150,10 @@ public class ArticleHelper {
 	 */
 	public static LinkedHashMap<String, String> getMediumMap() {
 		LinkedHashMap<String, String> map = new LinkedHashMap<>();
-		map.put(null, "Bitte wählen Sie...");
-		map.put("http://purl.org/ontology/bibo/AudioDocument", "Audio");
-		map.put("http://rdvocab.info/termList/RDACarrierType/1050", "Video");
-		map.put("http://purl.org/ontology/bibo/Image", "Bild");
 		map.put("http://pbcore.org/vocabularies/instantiationMediaType#text",
-				"Text");
-		map.put("http://pbcore.org/vocabularies/instantiationMediaType#software",
-				"Software");
+				"Volltext");
+                map.put("http://purl.org/dc/terms/LicenseDocument","Autorenvertrag");
+                map.put("http://purl.org/vocab/frbr/core#supplement","Beilage");
 		map.put("http://purl.org/lobid/lv%23Miscellaneous", "Andere");
 		return map;
 	}


### PR DESCRIPTION
Branch changes map for "Art der Datei" fka "Medium" in order to match the ZB MEDs desires. As I used vocabularies and resources not instriduced before I'm not sure if this will be realy helpful. Please review patch 