### PR TITLE
set form object to null after usage

### DIFF
--- a/app/controllers/ZettelController.java
+++ b/app/controllers/ZettelController.java
@@ -191,6 +191,7 @@ public class ZettelController extends Controller {
 			play.Logger.debug(String.format("Content of model\n%s",
 					((ZettelModel) form.get()).print()));
 		}
+		form = null;
 		return result;
 	}
 


### PR DESCRIPTION
- this gives the carbage collector the opportunity to
delete the object and to close associated file descriptors
of type pipe