### PR TITLE
Cancel button should go back to the previous page

### DIFF
--- a/app/views/article.scala.html
+++ b/app/views/article.scala.html
@@ -97,7 +97,7 @@
 		}
 		<div class="form-group row">
 			<div class="col-sm-offset-8 col-sm-4">
-				<button id="cancel" class="btn cancel">Cancel</button>
+				<input id="cancel" class="cancel btn" type="button" value="Cancel" />
 				<input type="submit" value="Save" class="btn btn-success" />
 			</div>
 		</div>

--- a/app/views/client.scala.html
+++ b/app/views/client.scala.html
@@ -62,6 +62,10 @@
 					'action'  : 'postDataToZettel'
 				}, "*");
 			}
+ 		 	target.postMessage({
+				'message' : document.referrer,
+				'action'  : 'sendReferrer'
+			}, "*");
 		} else if (e.data.action == 'resize') {
 			var targetHeight = e.data.message;
 			jQuery('#iFrame').height(targetHeight);

--- a/app/views/client.scala.html
+++ b/app/views/client.scala.html
@@ -67,6 +67,9 @@
 			jQuery('#iFrame').height(targetHeight);
 		} else if (e.data.action == 'postData') {
 			getMessage(e.data.message);
+		}else if (e.data.action == 'cancel') {
+			console.log(e.data.message);
+			window.location.href =e.data.message;
 		}
 	}
 

--- a/app/views/zettel.scala.html
+++ b/app/views/zettel.scala.html
@@ -25,7 +25,7 @@
 <script src="@controllers.routes.Assets.versioned("javascripts/moment.min.js")"></script>
 <script src="@controllers.routes.Assets.versioned("javascripts/daterangepicker.js")"></script>
 <script src="@controllers.routes.Assets.versioned("javascripts/leaflet.js")"></script>
-
+<script src="@controllers.routes.Assets.versioned("javascripts/js.cookie.js")"></script>
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE10">
@@ -72,8 +72,10 @@
 		enableHelpOpenButtons();
 		enableHelpCloseButtons();
 		addGeonamesLookup();
-		addGeonamesReverseLookup();		
+		addGeonamesReverseLookup();	
+		addActionToCancelButton();
 	});
+
 	</script>
 </body>
 </html>

--- a/public/javascripts/js.cookie.js
+++ b/public/javascripts/js.cookie.js
@@ -1,0 +1,165 @@
+/*!
+ * JavaScript Cookie v2.1.4
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+	var registeredInModuleLoader = false;
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+		registeredInModuleLoader = true;
+	}
+	if (typeof exports === 'object') {
+		module.exports = factory();
+		registeredInModuleLoader = true;
+	}
+	if (!registeredInModuleLoader) {
+		var OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				// We're using "expires" because "max-age" is not supported by IE
+				attributes.expires = attributes.expires ? attributes.expires.toUTCString() : '';
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				if (!converter.write) {
+					value = encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				} else {
+					value = converter.write(value, key);
+				}
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				var stringifiedAttributes = '';
+
+				for (var attributeName in attributes) {
+					if (!attributes[attributeName]) {
+						continue;
+					}
+					stringifiedAttributes += '; ' + attributeName;
+					if (attributes[attributeName] === true) {
+						continue;
+					}
+					stringifiedAttributes += '=' + attributes[attributeName];
+				}
+				return (document.cookie = key + '=' + value + stringifiedAttributes);
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					var name = parts[0].replace(rdecode, decodeURIComponent);
+					cookie = converter.read ?
+						converter.read(cookie, name) : converter(cookie, name) ||
+						cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.set = api;
+		api.get = function (key) {
+			return api.call(api, key);
+		};
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));

--- a/public/javascripts/zettel.js
+++ b/public/javascripts/zettel.js
@@ -677,25 +677,14 @@ function initRevMap(lat,lng){
 function addActionToCancelButton(){
 	if (top != self){
 		var sourceUrl=top.document.referrer;
-		console.log("Top source "+ top.document.referrer);
 		var targetUrl=decodeURIComponent(window.location.href);
-		console.log("Target "+ targetUrl);
 		if( sourceUrl !== targetUrl){
 			Cookies.set("cancel",top.document.referrer);
 		}
-		console.log("Set cookie to " + Cookies.get("cancel"));
-		/**
-		 * Argh - not proud of this one
-		 */
-		setTimeout(
-				function(){
-					$("#cancel").click(
-							function(){
-								top.window.location.href = Cookies.get("cancel");
-							}
-					);
-					
-				},3000);
+		setTimeout(function(){
+		$("#cancel").click(function(){
+			emitCancel();
+		});},3000);
 	}else{
 		var sourceUrl=document.referrer;
 		var targetUrl=decodeURIComponent(window.location.href);
@@ -708,4 +697,21 @@ function addActionToCancelButton(){
 	}
 	
 }
+
+function emitCancel() {
+	var target = parent.postMessage ? parent
+			: (parent.document.postMessage ? parent.document : undefined);
+	if (typeof target != "undefined") {
+		postCancel(target);
+	}
+}
+
+function postCancel(target) {
+	var cookie=Cookies.get("cancel");
+	target.postMessage({
+		'action' : 'cancel',
+		'message' : cookie
+	}, '*');
+}
+
 	

--- a/public/javascripts/zettel.js
+++ b/public/javascripts/zettel.js
@@ -673,3 +673,39 @@ function initRevMap(lat,lng){
 	}).addTo(mymap);
 	return mymap;
 }
+
+function addActionToCancelButton(){
+	if (top != self){
+		var sourceUrl=top.document.referrer;
+		console.log("Top source "+ top.document.referrer);
+		var targetUrl=decodeURIComponent(window.location.href);
+		console.log("Target "+ targetUrl);
+		if( sourceUrl !== targetUrl){
+			Cookies.set("cancel",top.document.referrer);
+		}
+		console.log("Set cookie to " + Cookies.get("cancel"));
+		/**
+		 * Argh - not proud of this one
+		 */
+		setTimeout(
+				function(){
+					$("#cancel").click(
+							function(){
+								top.window.location.href = Cookies.get("cancel");
+							}
+					);
+					
+				},3000);
+	}else{
+		var sourceUrl=document.referrer;
+		var targetUrl=decodeURIComponent(window.location.href);
+		if( sourceUrl !== targetUrl){
+			Cookies.set("cancel",document.referrer);
+		}
+		$("#cancel").click(function(){
+			window.location.href = Cookies.get("cancel");
+		});
+	}
+	
+}
+	

--- a/public/javascripts/zettel.js
+++ b/public/javascripts/zettel.js
@@ -352,6 +352,9 @@ function handleMessage(evt) {
 
 			}
 		});
+	} else if(evt.data.action === 'sendReferrer'){
+		var sourceUrl=evt.data.message;
+		Cookies.set("cancel",sourceUrl);
 	}
 }
 function destroyGndAutocompletion() {
@@ -676,11 +679,6 @@ function initRevMap(lat,lng){
 
 function addActionToCancelButton(){
 	if (top != self){
-		var sourceUrl=top.document.referrer;
-		var targetUrl=decodeURIComponent(window.location.href);
-		if( sourceUrl !== targetUrl){
-			Cookies.set("cancel",top.document.referrer);
-		}
 		setTimeout(function(){
 		$("#cancel").click(function(){
 			emitCancel();


### PR DESCRIPTION
- first tricky thing: The cancel button has to ignore navigation
within the formular if previous page is the form itself, e.g.
in case of a failed POST.
- second tricky thing: everything must work when page is loaded
within an IFrame, too.
- current implementation sets a cookie when entering the form. But
only if the previous page is not the form page itself. The cancel
button reads the page adress from the cookie and reloads the page.